### PR TITLE
Regenerate the catalogue when adding resources dynamically.

### DIFF
--- a/Translator.php
+++ b/Translator.php
@@ -73,6 +73,9 @@ class Translator implements TranslatorInterface
     public function addResource($format, $resource, $locale, $domain = 'messages')
     {
         $this->resources[$locale][] = array($format, $resource, $domain);
+        
+        // The catalogue should be regenerated when dynamically adding resources.
+        $this->loadCatalogue($locale);
     }
 
     /**


### PR DESCRIPTION
When adding resources after retrieving a translated string for the first time, they won't be taken into account when translating other strings later on.

Without this change, that is.

Related issue on Illuminate: https://github.com/illuminate/translation/issues/1
