### PR TITLE
Consider the numeric messages as same as fallback

### DIFF
--- a/DataCollectorTranslator.php
+++ b/DataCollectorTranslator.php
@@ -123,7 +123,7 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
         $locale = $catalogue->getLocale();
         if ($catalogue->defines($id, $domain)) {
             $state = self::MESSAGE_DEFINED;
-        } elseif ($catalogue->has($id, $domain)) {
+        } elseif ($catalogue->has($id, $domain) || is_numeric($translation)) {
             $state = self::MESSAGE_EQUALS_FALLBACK;
 
             $fallbackCatalogue = $catalogue->getFallBackCatalogue();


### PR DESCRIPTION
It does not make sense to warn the user because "2015" or "10" are not translated.
Maybe numeric values should not be counted at all