### PR TITLE
Blank between strings

### DIFF
--- a/Dumper/PoFileDumper.php
+++ b/Dumper/PoFileDumper.php
@@ -41,6 +41,7 @@ class PoFileDumper extends FileDumper
             }
             $output .= sprintf('msgid "%s"'."\n", $this->escape($source));
             $output .= sprintf('msgstr "%s"', $this->escape($target));
+            $output .= "\n";
         }
 
         return $output;


### PR DESCRIPTION
For example Crowdin.com (translation service) does not "see"  more than first string if there is no delimiter between strings.
