### PR TITLE
Process multiple segments within a single unit.

### DIFF
--- a/Loader/XliffFileLoader.php
+++ b/Loader/XliffFileLoader.php
@@ -123,36 +123,37 @@ class XliffFileLoader implements LoaderInterface
         $xml->registerXPathNamespace('xliff', 'urn:oasis:names:tc:xliff:document:2.0');
 
         foreach ($xml->xpath('//xliff:unit') as $unit) {
-            $segment = $unit->segment;
-            $source = $segment->source;
+            foreach ($unit->segment as $segment) {
+                $source = $segment->source;
 
-            // If the xlf file has another encoding specified, try to convert it because
-            // simple_xml will always return utf-8 encoded values
-            $target = $this->utf8ToCharset((string) (isset($segment->target) ? $segment->target : $source), $encoding);
+                // If the xlf file has another encoding specified, try to convert it because
+                // simple_xml will always return utf-8 encoded values
+                $target = $this->utf8ToCharset((string) (isset($segment->target) ? $segment->target : $source), $encoding);
 
-            $catalogue->set((string) $source, $target, $domain);
+                $catalogue->set((string) $source, $target, $domain);
 
-            $metadata = array();
-            if (isset($segment->target) && $segment->target->attributes()) {
-                $metadata['target-attributes'] = array();
-                foreach ($segment->target->attributes() as $key => $value) {
-                    $metadata['target-attributes'][$key] = (string) $value;
-                }
-            }
-
-            if (isset($unit->notes)) {
-                $metadata['notes'] = array();
-                foreach ($unit->notes->note as $noteNode) {
-                    $note = array();
-                    foreach ($noteNode->attributes() as $key => $value) {
-                        $note[$key] = (string) $value;
+                $metadata = array();
+                if (isset($segment->target) && $segment->target->attributes()) {
+                    $metadata['target-attributes'] = array();
+                    foreach ($segment->target->attributes() as $key => $value) {
+                        $metadata['target-attributes'][$key] = (string) $value;
                     }
-                    $note['content'] = (string) $noteNode;
-                    $metadata['notes'][] = $note;
                 }
-            }
 
-            $catalogue->setMetadata((string) $source, $metadata, $domain);
+                if (isset($unit->notes)) {
+                    $metadata['notes'] = array();
+                    foreach ($unit->notes->note as $noteNode) {
+                        $note = array();
+                        foreach ($noteNode->attributes() as $key => $value) {
+                            $note[$key] = (string) $value;
+                        }
+                        $note['content'] = (string) $noteNode;
+                        $metadata['notes'][] = $note;
+                    }
+                }
+
+                $catalogue->setMetadata((string) $source, $metadata, $domain);
+            }
         }
     }
 

--- a/Tests/Loader/XliffFileLoaderTest.php
+++ b/Tests/Loader/XliffFileLoaderTest.php
@@ -228,4 +228,33 @@ class XliffFileLoaderTest extends TestCase
         $this->assertEquals('quality', $metadata['notes'][1]['category']);
         $this->assertEquals('Fuzzy', $metadata['notes'][1]['content']);
     }
+
+    public function testLoadVersion2WithMultiSegmentUnit()
+    {
+        $loader = new XliffFileLoader();
+        $resource = __DIR__.'/../fixtures/resources-2.0-multi-segment-unit.xlf';
+        $catalog = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals('en', $catalog->getLocale());
+        $this->assertEquals(array(new FileResource($resource)), $catalog->getResources());
+        $this->assertSame(array(), libxml_get_errors());
+
+        // test for "foo" metadata
+        $this->assertTrue($catalog->defines('foo', 'domain1'));
+        $metadata = $catalog->getMetadata('foo', 'domain1');
+        $this->assertNotEmpty($metadata);
+        $this->assertCount(1, $metadata['notes']);
+
+        $this->assertEquals('processed', $metadata['notes'][0]['category']);
+        $this->assertEquals('true', $metadata['notes'][0]['content']);
+
+        // test for "bar" metadata
+        $this->assertTrue($catalog->defines('bar', 'domain1'));
+        $metadata = $catalog->getMetadata('bar', 'domain1');
+        $this->assertNotEmpty($metadata);
+        $this->assertCount(1, $metadata['notes']);
+
+        $this->assertEquals('processed', $metadata['notes'][0]['category']);
+        $this->assertEquals('true', $metadata['notes'][0]['content']);
+    }
 }

--- a/Tests/fixtures/resources-2.0-multi-segment-unit.xlf
+++ b/Tests/fixtures/resources-2.0-multi-segment-unit.xlf
@@ -1,0 +1,17 @@
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US" trgLang="en-US">
+    <file id="f1">
+        <unit id="1">
+            <notes>
+                <note category="processed">true</note>
+            </notes>
+            <segment id="id-foo">
+                <source>foo</source>
+                <target>foo (translated)</target>
+            </segment>
+            <segment id="id-bar">
+                <source>bar</source>
+                <target>bar (translated)</target>
+            </segment>
+        </unit>
+    </file>
+</xliff>


### PR DESCRIPTION
Xliff 2.0 supports multiple segments within a single unit, but the
loader was only processing the first segment.  The loader will now
correctly process all segments within a unit.