### PR TITLE
Update Translator.php setLocale()

### DIFF
--- a/Translator.php
+++ b/Translator.php
@@ -144,7 +144,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
     /**
      * {@inheritdoc}
      */
-    public function setLocale(string $locale)
+    public function setLocale($locale)
     {
         $this->assertValidLocale($locale);
         $this->locale = $locale;


### PR DESCRIPTION
Error: Symfony\Component\Debug\Exception\FatalErrorException Declaration of Symfony\Component\Translation\TranslatorInterface::setLocale($locale) must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::setLocale(string $locale)

Fix: Removed typing 'string' in Symfony\Contracts\Translation\LocaleAwareInterface::setLocale($locale)