### PR TITLE
Update TranslatorInterface.php setLocale()

### DIFF
--- a/TranslatorInterface.php
+++ b/TranslatorInterface.php
@@ -59,7 +59,7 @@ interface TranslatorInterface extends LocaleAwareInterface
      *
      * @throws InvalidArgumentException If the locale contains invalid characters
      */
-    public function setLocale($locale);
+    public function setLocale(string $locale);
 
     /**
      * Returns the current locale.


### PR DESCRIPTION
Error: Symfony\Component\Debug\Exception\FatalErrorException Declaration of Symfony\Component\Translation\TranslatorInterface::setLocale($locale) must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::setLocale(string $locale)

Fix: Add typing 'string' in C:\Bitnami\server\apps\gateway-link-api\vendor\symfony\translation\TranslatorInterface::setLocale(string $locale);