### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/translation-contracts": "^1.1.6|^2"
+        "symfony/translation-contracts": "^1.1.6"
     },
     "require-dev": {
         "symfony/config": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
Remove incompatible version of symfony/translation-contracts.

Version 2 of translation-contracts adds primitive type declaration which are not included in this version.

Resolves:
`Declaration of Symfony\Component\Translation\TranslatorInterface::setLocale($locale) must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::setLocale(string $locale)`