### PR TITLE
add parameter type declaration

### DIFF
--- a/TranslatorInterface.php
+++ b/TranslatorInterface.php
@@ -59,7 +59,7 @@ interface TranslatorInterface extends LocaleAwareInterface
      *
      * @throws InvalidArgumentException If the locale contains invalid characters
      */
-    public function setLocale($locale);
+    public function setLocale(string $locale);
 
     /**
      * Returns the current locale.


### PR DESCRIPTION
to conform to changes made: https://github.com/symfony/translation-contracts/commit/8feb81e6bb1a42d6a3b1429c751d291eb6d05297

using symfony/translation 4.4.0 and symfony/translation-contracts 2.0.1, the following exception is being thrown:

```
Declaration of Symfony\Component\Translation\TranslatorInterface::setLocale($locale) must be compatible with Symfony\Contracts\Translation\LocaleAwareInterface::setLocale(string $locale)
```