### PR TITLE
Add support for calling 'trans' with ICU formatted messages

### DIFF
--- a/Translator.php
+++ b/Translator.php
@@ -214,7 +214,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             }
         }
 
-        if ($this->hasIntlFormatter && $catalogue->defines($id, $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX)) {
+        if ($this->hasIntlFormatter
+            && ($catalogue->defines($id, $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX)
+                || strstr($domain, MessageCatalogue::INTL_DOMAIN_SUFFIX) != false))
+        {
             return $this->formatter->formatIntl($catalogue->get($id, $domain), $locale, $parameters);
         }
 
@@ -466,7 +469,11 @@ EOF
 
         foreach ($catalogue->all() as $domain => $messages) {
             if ($intlMessages = $catalogue->all($domain.MessageCatalogue::INTL_DOMAIN_SUFFIX)) {
-                $allMessages[$domain.MessageCatalogue::INTL_DOMAIN_SUFFIX] = $intlMessages;
+                if (strstr($domain, MessageCatalogue::INTL_DOMAIN_SUFFIX) === false) {
+                    $domain .= MessageCatalogue::INTL_DOMAIN_SUFFIX;
+                }
+
+                $allMessages[$domain] = $intlMessages;
                 $messages = array_diff_key($messages, $intlMessages);
             }
             if ($messages) {


### PR DESCRIPTION
Motivation:

```
$apples = [1 => '1 apple', '# apples'];
echo _m($apples, ['count' => 0]);
```

where `_m` is a wrapper my application is using, but we obviously don't want to replicate many of the effort of this repo, so it relies on `trans`.

See https://github.com/symfony/symfony/issues/37228