### PR TITLE
Added ArrayLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ $ composer require symfony/translation
 
 ```php
 use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 
 $translator = new Translator('fr_FR');
+$translator->addLoader('array', new ArrayLoader());
 $translator->addResource('array', [
     'Hello World!' => 'Bonjour !',
 ], 'fr_FR');


### PR DESCRIPTION
Following the instructions in the README I got this error:

`Fatal error: Uncaught Symfony\Component\Translation\Exception\RuntimeException: No loader is registered for the "array" format. in /var/www/html/vendor/symfony/translation/Translator.php:372 Stack trace: #0 /var/www/html/vendor/symfony/translation/Translator.php(266): Symfony\Component\Translation\Translator->doLoadCatalogue('fr_FR') #1 /var/www/html/vendor/symfony/translation/Translator.php(255): Symfony\Component\Translation\Translator->initializeCatalogue('fr_FR') #2 /var/www/html/vendor/symfony/translation/Translator.php(236): Symfony\Component\Translation\Translator->loadCatalogue('fr_FR') #3 /var/www/html/vendor/symfony/translation/Translator.php(206): Symfony\Component\Translation\Translator->getCatalogue('fr_FR') #4 /var/www/html/index.php(27): Symfony\Component\Translation\Translator->trans('private') #5 {main} thrown in /var/www/html/vendor/symfony/translation/Translator.php on line 372`

I must add ArrayLoader and $translator->addLoader to make it work.

