### PR TITLE
Fix update existing key with existing +int-icu domain

### DIFF
--- a/MessageCatalogue.php
+++ b/MessageCatalogue.php
@@ -167,7 +167,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
         }
         $intlDomain = $domain;
         $suffixLength = \strlen(self::INTL_DOMAIN_SUFFIX);
-        if (\strlen($domain) > $suffixLength && false !== strpos($domain, self::INTL_DOMAIN_SUFFIX, -$suffixLength)) {
+        if (\strlen($domain) < $suffixLength || false === strpos($domain, self::INTL_DOMAIN_SUFFIX, -$suffixLength)) {
             $intlDomain .= self::INTL_DOMAIN_SUFFIX;
         }
         foreach ($messages as $id => $message) {


### PR DESCRIPTION
Using php-translation webui interface, I tried to update an existing +int-icu domain but a regular domain was created and the existing key wasn't updated. Looks like in the method I modified, we should have been looking for a potential domain+intl-icu domain and try it