### PR TITLE
Fix: translation:push command diff using intl-icu

### DIFF
--- a/Command/TranslationTrait.php
+++ b/Command/TranslationTrait.php
@@ -49,7 +49,7 @@ trait TranslationTrait
         // extract intl-icu messages only
         $intlDomain = $domain.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
         if ($intlMessages = $catalogue->all($intlDomain)) {
-            $filteredCatalogue->add($intlMessages, $intlDomain);
+            $filteredCatalogue->add($intlMessages, $domain);
         }
 
         // extract all messages and subtract intl-icu messages


### PR DESCRIPTION
Provider translations do not come back with "+intl-icu" in `$provider->read($domains, $locales);`, so local translations should not include it for the diff.